### PR TITLE
change sftp as extention of pg backups

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,12 @@
-FROM ubuntu:12.04
+FROM kartoza/pg-backup:9.4
 MAINTAINER Rizky Maulana Nugraha<lana.pcfre@gmail.com>
 
 RUN apt-get update
-RUN apt-get install -y cron python-dev python-pip python-paramiko build-essential
+RUN apt-get install -y cron
+RUN apt-get install -y python-dev
+RUN apt-get install -y python-pip
+RUN apt-get install -y python-paramiko
+RUN apt-get install -y build-essential
 RUN pip install --upgrade paramiko
 ADD backups-cron /etc/cron.d/backups-cron
 RUN touch /var/log/cron.log

--- a/backups.sh
+++ b/backups.sh
@@ -14,10 +14,35 @@ cd ${MYBACKUPDIR}
 
 echo "Backup running to $MYBACKUPDIR" >> /var/log/cron.log
 
+# ------------------------------------------------------------------------
+# BACKUP Postgree First
+# Loop through each pg database backing it up
+# ------------------------------------------------------------------------
+DBLIST=`psql -l | awk '{print $1}' | grep -v "+" | grep -v "Name" | grep -v "List" | grep -v "(" | grep -v "template" | grep -v "postgres" | grep -v "|" | grep -v ":"`
+# echo "Databases to backup: ${DBLIST}" >> /var/log/cron.log
+for DB in ${DBLIST}
+do
+  echo "Backing up $DB"  >> /var/log/cron.log
+  FILENAME=${MYBACKUPDIR}/${DUMPPREFIX}_${DB}.${MYDATE}.dmp
+  pg_dump -i -Fc -f ${FILENAME} -x -O ${DB}
+done
 
-echo "Backing up $TARGET_FOLDER"  >> /var/log/cron.log
+FILENAME=${MYBACKUPDIR}/[GLOBAL]${DUMPPREFIX}.${MYDATE}.sql
+pg_dumpall -i -f ${FILENAME} -x -O --globals-only
+
+
+# ------------------------------------------------------------------------
+# Preparing for sftp backups
+# ------------------------------------------------------------------------
 FILENAME=${MYBACKUPDIR}/${DUMPPREFIX}.${MYDATE}.tar.gz
-tar -zcvf ${FILENAME} ${TARGET_FOLDER}/*
+echo "Creating compressed file $FILENAME"  >> /var/log/cron.log
+
+cd ${MYBACKUPDIR}
+FILES=`ls -I "*.tar.gz" | grep ${MYDATE}`
+tar -zcvf ${FILENAME} ${FILES}
+
+# ------------------------------------------------------------------------
+# push to remote sever
+# ------------------------------------------------------------------------
 echo "push backup to remote server" >> /var/log/cron.log
 /usr/bin/python /sftp_remote.py ${FILENAME} >> /var/log/cron.log
-

--- a/cleanup.py
+++ b/cleanup.py
@@ -9,7 +9,6 @@ import math
 import sftp_remote
 from sftp_remote import get_sftp_session
 
-
 __author__ = 'lucernae'
 __email__ = 'lana.pcfre@gmail.com'
 
@@ -40,13 +39,10 @@ def main():
         # process files
         for f in files:
             # extract timestamp from name in the format:
-            time_format = '%d-%B-%Y'
-            dump_format = '%s.%s.tar.gz' % (
-                dump_prefix,
-                time_format
-            )
             try:
-                dump_time = datetime.strptime(f, dump_format)
+                time_format = '%d-%B-%Y'
+                file_time = f.split('.')[1]
+                dump_time = datetime.strptime(file_time, time_format)
 
                 file_path = os.path.join(root, f)
                 time_diff = today - dump_time
@@ -85,7 +81,7 @@ def main():
                         except Exception as e:
                             print e.message
 
-            except ValueError:
+            except (ValueError, IndexError):
                 continue
 
         # process dirs


### PR DESCRIPTION
- updated sftp as extension of pg backups
- updated pg backups to also backup role
- it will make backup files first from pg backups, and after that create tar gz to be pushed to remote server
- tower of hanoi implemented not just to tar gz, but also other files extension
- merged target folder to backups folder, to prevent duplicated files
- compresed now working just for specific date with specific filename, not all files in "Target Folder" like before

Screenshot
![screenshot from 2016-12-05 14 22 53](https://cloud.githubusercontent.com/assets/4530905/20876822/2bbd6396-baf7-11e6-9c2b-be8cb97e0cbf.png)
![screenshot from 2016-12-05 14 23 04](https://cloud.githubusercontent.com/assets/4530905/20876823/2bc0bc4e-baf7-11e6-9d70-1a8a76f67638.png)

@lucernae @timlinux 


